### PR TITLE
Render hidden element as such

### DIFF
--- a/lib/HTML/QuickForm/hidden.php
+++ b/lib/HTML/QuickForm/hidden.php
@@ -38,5 +38,13 @@ class HTML_QuickForm_hidden extends HTML_QuickForm_input
     {
         return false;
     }
+
+	/**
+    * Render the element as a hidden field
+    */
+    public function accept(HTML_QuickForm_Renderer &$renderer, $required = false, $error = null)
+    {
+        $renderer->renderHidden($this, $required, $error);
+    }
 }
 ?>


### PR DESCRIPTION
With the table-based layout (and possibly others), the hidden elements get 'empty rows' for each hidden element. With this patch, they're rendered as part of the hidden sections, just like the original QuickForm-implementation.