### PR TITLE
changed visibilities for proper inheritance of HTML_QuickForm_Rendere…

### DIFF
--- a/lib/HTML/QuickForm/Renderer/Array.php
+++ b/lib/HTML/QuickForm/Renderer/Array.php
@@ -96,28 +96,28 @@ class HTML_QuickForm_Renderer_Array extends HTML_QuickForm_Renderer
      *
      * @var array
      */
-    private $_ary;
+    protected $_ary;
 
     /**
      * Number of sections in the form (i.e. number of headers in it)
      *
      * @var integer
      */
-    private $_sectionCount;
+    protected $_sectionCount;
 
     /**
      * Current section number
      *
      * @var integer
      */
-    private $_currentSection;
+    protected $_currentSection;
 
     /**
      * Array representing current group
      *
      * @var array
      */
-    private $_currentGroup = null;
+    protected $_currentGroup = null;
 
     /**
      * Additional style information for different elements
@@ -178,7 +178,6 @@ class HTML_QuickForm_Renderer_Array extends HTML_QuickForm_Renderer
         if ($this->_collectHidden) {
             $this->_ary['hidden'] = '';
         }
-        $this->_elementIdx     = 1;
         $this->_currentSection = null;
         $this->_sectionCount   = 0;
     }
@@ -247,7 +246,7 @@ class HTML_QuickForm_Renderer_Array extends HTML_QuickForm_Renderer
      * @param  string                    Error associated with the element
      * @return array
      */
-    private function _elementToArray(&$element, $required, $error)
+    protected function _elementToArray(&$element, $required, $error)
     {
         $ret = array(
             'name'      => $element->getName(),
@@ -291,7 +290,7 @@ class HTML_QuickForm_Renderer_Array extends HTML_QuickForm_Renderer
      *
      * @param array  Array representation of an element
      */
-    private function _storeArray($elAry)
+    protected function _storeArray($elAry)
     {
         // where should we put this element...
         if (is_array($this->_currentGroup) && ('group' != $elAry['type'])) {

--- a/lib/HTML/QuickForm/Renderer/ArraySmarty.php
+++ b/lib/HTML/QuickForm/Renderer/ArraySmarty.php
@@ -68,41 +68,37 @@
  */
 class HTML_QuickForm_Renderer_ArraySmarty extends HTML_QuickForm_Renderer_Array
 {
-   /**#@+
-    * @access private
-    */
    /**
     * The Smarty template engine instance
     * @var object
     */
-    var $_tpl = null;
+    private $_tpl = null;
 
    /**
     * Current element index
     * @var integer
     */
-    var $_elementIdx = 0;
+    private $_elementIdx = 0;
 
     /**
     * The current element index inside a group
     * @var integer
     */
-    var $_groupElementIdx = 0;
+    private $_groupElementIdx = 0;
 
    /**
     * How to handle the required tag for required fields
     * @var string
     * @see      setRequiredTemplate()
     */
-    var $_required = '';
+    private $_required = '';
 
    /**
     * How to handle error messages in form validation
     * @var string
     * @see      setErrorTemplate()
     */
-    var $_error = '';
-   /**#@-*/
+    private $_error = '';
 
    /**
     * Constructor
@@ -115,6 +111,17 @@ class HTML_QuickForm_Renderer_ArraySmarty extends HTML_QuickForm_Renderer_Array
     {
         parent::__construct($collectHidden, $staticLabels);
         $this->_tpl =& $tpl;
+    }
+
+    /**
+     * Called when visiting a form, before processing any form elements
+     *
+     * @param    HTML_QuickForm  a form being visited
+     */
+    public function startForm(&$form)
+    {
+        parent::startForm($form);
+        $this->_elementIdx = 1;
     }
 
    /**
@@ -155,7 +162,7 @@ class HTML_QuickForm_Renderer_ArraySmarty extends HTML_QuickForm_Renderer_Array
     * @param  string                    Error associated with the element
     * @return array
     */
-    function _elementToArray(&$element, $required, $error)
+    protected function _elementToArray(&$element, $required, $error)
     {
         $ret = parent::_elementToArray($element, $required, $error);
 
@@ -224,7 +231,7 @@ class HTML_QuickForm_Renderer_ArraySmarty extends HTML_QuickForm_Renderer_Array
     * @access private
     * @param array  Array representation of an element
     */
-    function _storeArray($elAry)
+    protected function _storeArray($elAry)
     {
         if ($elAry) {
             $sKeys = $elAry['keys'];
@@ -253,7 +260,7 @@ class HTML_QuickForm_Renderer_ArraySmarty extends HTML_QuickForm_Renderer_Array
     * @see      setRequiredTemplate()
     * @access   private
     */
-    function _renderRequired(&$label, &$html, &$required, &$error)
+    private function _renderRequired(&$label, &$html, &$required, &$error)
     {
         $this->_tpl->assign(array(
             'label'    => $label,
@@ -283,7 +290,7 @@ class HTML_QuickForm_Renderer_ArraySmarty extends HTML_QuickForm_Renderer_Array
     * @see      setErrorTemplate()
     * @access   private
     */
-    function _renderError(&$label, &$html, &$error)
+    private function _renderError(&$label, &$html, &$error)
     {
         $this->_tpl->assign(array('label' => '', 'html' => '', 'error' => $error));
         $error = $this->_tplFetch($this->_error);
@@ -306,7 +313,7 @@ class HTML_QuickForm_Renderer_ArraySmarty extends HTML_QuickForm_Renderer_Array
     * @param    string      The template source
     * @access   private
     */
-    function _tplFetch($tplSource)
+    private function _tplFetch($tplSource)
     {
         if (!function_exists('smarty_function_eval')) {
             require SMARTY_DIR . '/plugins/function.eval.php';


### PR DESCRIPTION
…r_ArraySmarty

There were some methods and property in HTML_QuickForm_Renderer_Array
that could not be overloaded in HTML_QuickForm_Renderer_ArraySmarty
because of the private access level - this lead to an unexpected output
of HTML_QuickForm_Renderer_ArraySmarty.

Also I removed the initialisation of $_elementIdx from
Renderer_Array::startForm() because the prperty was not decelerated nor
used in Renderer_Array and created a Renderer_ArraySmarty::startForm()
which inits $_elementIdx now.