### PR TITLE
Fix 'hierselect' init fail.

### DIFF
--- a/lib/HTML/QuickForm/group.php
+++ b/lib/HTML/QuickForm/group.php
@@ -329,19 +329,6 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
         return true;
     }
 
-    /**
-     * Call \HTML_QuickForm_element::onQuickFormEvent()
-     *
-     * @param     string    $event      Name of event
-     * @param     mixed     $arg        event arguments
-     * @param     object    &$caller    calling object
-     * @return bool
-     */
-    protected function element_onQuickFormEvent($event, $arg, &$caller)
-    {
-        return parent::onQuickFormEvent($event, $arg, $caller);
-    }
-
    /**
     * Accepts a renderer
     *

--- a/lib/HTML/QuickForm/group.php
+++ b/lib/HTML/QuickForm/group.php
@@ -329,6 +329,19 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
         return true;
     }
 
+    /**
+     * Call \HTML_QuickForm_element::onQuickFormEvent()
+     *
+     * @param     string    $event      Name of event
+     * @param     mixed     $arg        event arguments
+     * @param     object    &$caller    calling object
+     * @return bool
+     */
+    protected function element_onQuickFormEvent($event, $arg, &$caller)
+    {
+        return parent::onQuickFormEvent($event, $arg, $caller);
+    }
+
    /**
     * Accepts a renderer
     *

--- a/lib/HTML/QuickForm/hierselect.php
+++ b/lib/HTML/QuickForm/hierselect.php
@@ -425,7 +425,7 @@ JAVASCRIPT;
         if ('updateValue' == $event) {
             // we need to call setValue() so that the secondary option
             // matches the main option
-            return parent::onQuickFormEvent($event, $arg, $caller);
+            return parent::element_onQuickFormEvent($event, $arg, $caller);
         } else {
             $ret = parent::onQuickFormEvent($event, $arg, $caller);
             // add onreset handler to form to properly reset hierselect (see bug #2970)

--- a/lib/HTML/QuickForm/hierselect.php
+++ b/lib/HTML/QuickForm/hierselect.php
@@ -425,7 +425,7 @@ JAVASCRIPT;
         if ('updateValue' == $event) {
             // we need to call setValue() so that the secondary option
             // matches the main option
-            return parent::element_onQuickFormEvent($event, $arg, $caller);
+            return HTML_QuickForm_element::onQuickFormEvent($event, $arg, $caller);
         } else {
             $ret = parent::onQuickFormEvent($event, $arg, $caller);
             // add onreset handler to form to properly reset hierselect (see bug #2970)


### PR DESCRIPTION
Hi, thank you for maintain QuickForm.
I found issue about initialization of 'hierselect', and fix it.
Please review this fix.

# Summary
When adding hierselect, `\HTML_QuickForm_hierselect::onQuickFormEvent()` calls `parent::onQuickFormEvent()`.
(accurately `\HTML_QuickForm_group::onQuickFormEvent()`)
`\HTML_QuickForm_group::onQuickFormEvent()` try to make instance of `\HTML_QuickForm_select` to `$this->_elements`.
But no instance created, because `$this->_nbElements` is null.
(`$this->_nbElements` is `count($this->_elements)`)
Original source was calling `\HTML_QuickForm_element::onQuickFormEvent()` from `\HTML_QuickForm_hierselect::onQuickFormEvent()` directly.
`\HTML_QuickForm_element::onQuickFormEvent()` initialize default values and make instance of `\HTML_QuickForm_select`.
It doesn't care `$this->_elements` or `$this->_nbElements`.
So, I add by-pass to call `\HTML_QuickForm_element::onQuickFormEvent()` on `\HTML_QuickForm_group`.