### PR TITLE
Fix 'hierselect' attributes

### DIFF
--- a/lib/HTML/QuickForm/hierselect.php
+++ b/lib/HTML/QuickForm/hierselect.php
@@ -60,7 +60,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
      */
     function __construct($elementName=null, $elementLabel=null, $attributes=null, $separator=null)
     {
-        parent::__construct($elementName, $elementLabel, $attributes);
+        HTML_QuickForm_element::__construct($elementName, $elementLabel, $attributes);
         $this->_persistantFreeze = true;
         if (isset($separator)) {
             $this->_separator = $separator;


### PR DESCRIPTION
Hi, thank you for maintain QuickForm.
I found issue about attributes of 'hierselect', and fix it.
Please review this fix.

example is bellow
```
$form = new HTML_QuickForm();
$form->addElement(new HTML_QuickForm_hierselect('test', 'test label',$this->_attr[color_attributes]));
$form->setDefaults([]);
$form->display();
```
